### PR TITLE
feat: use async/await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ build
 node_modules
 
 dist
+
+package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ language: node_js
 
 matrix:
   include:
-  - node_js: 6
-    env: CXX=g++-4.8
   - node_js: 8
+    env: CXX=g++-4.8
+  - node_js: 10
     env: CXX=g++-4.8
     #  - node_js: stable
     #    env: CXX=g++-4.8

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 
 > Support for secp256k1 keys in js-libp2p-crypto
 
-This repo contains a [js-libp2p-crypto](https://github.com/libp2p/js-libp2p-crypto)-compatible 
-implementation of cryptographic signature generation and verification using the 
-[secp256k1 elliptic curve](https://en.bitcoin.it/wiki/Secp256k1) popularized by Bitcoin and other 
+This repo contains a [js-libp2p-crypto](https://github.com/libp2p/js-libp2p-crypto)-compatible
+implementation of cryptographic signature generation and verification using the
+[secp256k1 elliptic curve](https://en.bitcoin.it/wiki/Secp256k1) popularized by Bitcoin and other
 crypto currencies.  
 
 ## Lead Captain
@@ -25,14 +25,14 @@ crypto currencies.
 - [Usage](#usage)
   - [Example](#example)
 - [API](#api)
-  - [`generateKeyPair([bits,] callback)`](#generatekeypairbits-callback)
+  - [`generateKeyPair([bits])`](#generatekeypairbits)
   - [`unmarshalSecp256k1PublicKey(bytes)`](#unmarshalsecp256k1publickeybytes)
-  - [`unmarshalSecp256k1PrivateKey(bytes, callback)`](#unmarshalsecp256k1privatekeybytes-callback)
+  - [`unmarshalSecp256k1PrivateKey(bytes)`](#unmarshalsecp256k1privatekeybytes)
   - [`Secp256k1PublicKey`](#secp256k1publickey)
-    - [`.verify(data, sig, callback)`](#verifydata-sig-callback)
+    - [`.verify(data, sig)`](#verifydata-sig)
   - [`Secp256k1PrivateKey`](#secp256k1privatekey)
     - [`.public`](#public)
-    - [`.sign(data, callback)`](#signdata-callback)
+    - [`.sign(data)`](#signdata)
 - [Contribute](#contribute)
 - [License](#license)
 
@@ -54,48 +54,48 @@ instances of the `Secp256k1PublicKey` or `Secp256k1PrivateKey` classes provided 
 
 ```js
 const crypto = require('libp2p-crypto')
-
 const msg = Buffer.from('Hello World')
 
-crypto.generateKeyPair('secp256k1', 256, (err, key) => {
-  // assuming no error, key will be an instance of Secp256k1PrivateKey
-  // the public key is available as key.public
-  key.sign(msg, (err, sig) => {
-    key.public.verify(msg, sig, (err, valid) => {
-      assert(valid, 'Something went horribly wrong')
-    })
-  })
-})
+const key = await crypto.generateKeyPair('secp256k1', 256)
+// assuming no error, key will be an instance of Secp256k1PrivateKey
+// the public key is available as key.public
+const sig = await key.sign(msg)
+
+const valid = await key.public.verify(msg, sig)
+assert(valid, 'Something went horribly wrong')
 ```
 
 ## API
 
 The functions below are the public API of this module.
-For usage within libp2p-crypto, see the [libp2p-crypto API documentation](https://github.com/libp2p/js-libp2p-crypto#api).
+For usage within `libp2p-crypto`, see the [`libp2p-crypto` API documentation](https://github.com/libp2p/js-libp2p-crypto#api).
 
-### `generateKeyPair([bits, ] callback)`
+### `generateKeyPair([bits])`
 - `bits: Number` - Optional, included for compatibility with js-libp2p-crypto. Ignored if present; private keys will always be 256 bits.
-- `callback: Function`
+
+Returns `Promise<Secp256k1PrivateKey>`
 
 ### `unmarshalSecp256k1PublicKey(bytes)`
 - `bytes: Buffer`
 
 Converts a serialized secp256k1 public key into an instance of `Secp256k1PublicKey` and returns it
 
-### `unmarshalSecp256k1PrivateKey(bytes, callback)`
+### `unmarshalSecp256k1PrivateKey(bytes)`
 - `bytes: Buffer`
-- `callback: Function`
 
-Converts a serialized secp256k1 private key into an instance of `Secp256k1PrivateKey`, passing it to `callback` on success
+Returns `Promise<Secp256k1PrivateKey>`
+
+Converts a serialized secp256k1 private key into an instance of `Secp256k1PrivateKey`.
 
 ### `Secp256k1PublicKey`
 
-#### `.verify(data, sig, callback)`
+#### `.verify(data, sig)`
 - `data: Buffer`
 - `sig: Buffer`
-- `callback: Function`
 
-Calculates the SHA-256 hash of `data`, and verifies the DER-encoded signature in `sig`, passing the result to `callback`
+Returns `Promise<Boolean>`
+
+Calculates the SHA-256 hash of `data`, and verifies the DER-encoded signature in `sig`.
 
 ### `Secp256k1PrivateKey`
 
@@ -103,14 +103,16 @@ Calculates the SHA-256 hash of `data`, and verifies the DER-encoded signature in
 
 Accessor for the `Secp256k1PublicKey` associated with this private key.
 
-#### `.sign(data, callback)`
+#### `.sign(data)`
 - `data: Buffer`
 
-Calculates the SHA-256 hash of `data` and signs it, passing the DER-encoded signature to `callback`
+Returns `Promise<Buffer>`
+
+Calculates the SHA-256 hash of `data` and signs it, resolves with the DER-encoded signature.
 
 ## Contribute
 
-Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/js-libp2p-crypto/issues)!
+Feel free to join in. All welcome. Open an [issue](https://github.com/libp2p/js-libp2p-crypto-secp256k1/issues)!
 
 This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
 

--- a/package.json
+++ b/package.json
@@ -8,16 +8,16 @@
     "secp256k1": "secp256k1/js"
   },
   "scripts": {
-    "lint": "aegir-lint",
-    "build": "aegir-build",
+    "lint": "aegir lint",
+    "build": "aegir build",
     "test": "npm run test:node && npm run test:browser",
-    "test:node": "aegir-test --env node",
-    "test:browser": "aegir-test --env browser",
-    "release": "aegir-release",
-    "release-minor": "aegir-release --type minor",
-    "release-major": "aegir-release --type major",
-    "coverage": "aegir-coverage",
-    "coverage-publish": "aegir-coverage publish"
+    "test:node": "aegir test -t node",
+    "test:browser": "aegir test -t browser",
+    "release": "aegir release",
+    "release-minor": "aegir release --type minor",
+    "release-major": "aegir release --type major",
+    "coverage": "aegir coverage",
+    "coverage-publish": "aegir coverage publish"
   },
   "keywords": [
     "IPFS",
@@ -27,18 +27,15 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "async": "^2.6.0",
-    "multihashing-async": "~0.4.8",
-    "nodeify": "^1.0.1",
-    "safe-buffer": "^5.1.2",
+    "multihashing-async": "^0.5.1",
     "secp256k1": "^3.5.0"
   },
   "devDependencies": {
-    "aegir": "^13.1.0",
+    "aegir": "^17.0.0",
     "benchmark": "^2.1.4",
-    "libp2p-crypto": "~0.13.0",
     "chai": "^4.1.2",
-    "dirty-chai": "^2.0.1"
+    "dirty-chai": "^2.0.1",
+    "libp2p-crypto": "^0.14.0"
   },
   "engines": {
     "node": ">=6.0.0",

--- a/src/crypto.js
+++ b/src/crypto.js
@@ -2,49 +2,40 @@
 
 const secp256k1 = require('secp256k1')
 const multihashing = require('multihashing-async')
-const setImmediate = require('async/setImmediate')
 
 const HASH_ALGORITHM = 'sha2-256'
 
 module.exports = (randomBytes) => {
   const privateKeyLength = 32
 
-  function generateKey (callback) {
-    const done = (err, res) => setImmediate(() => callback(err, res))
-
+  async function generateKey () {
     let privateKey
     do {
       privateKey = randomBytes(32)
     } while (!secp256k1.privateKeyVerify(privateKey))
-
-    done(null, privateKey)
+    return privateKey
   }
 
-  function hashAndSign (key, msg, callback) {
-    const done = (err, res) => setImmediate(() => callback(err, res))
-
-    multihashing.digest(msg, HASH_ALGORITHM, (err, digest) => {
-      if (err) { return done(err) }
-
-      try {
-        const sig = secp256k1.sign(digest, key)
-        const sigDER = secp256k1.signatureExport(sig.signature)
-        return done(null, sigDER)
-      } catch (err) { done(err) }
+  async function hashAndSign (key, msg) {
+    const digest = await new Promise((resolve, reject) => {
+      multihashing.digest(msg, HASH_ALGORITHM, (err, digest) => {
+        if (err) return reject(err)
+        resolve(digest)
+      })
     })
+    const sig = secp256k1.sign(digest, key)
+    return secp256k1.signatureExport(sig.signature)
   }
 
-  function hashAndVerify (key, sig, msg, callback) {
-    const done = (err, res) => setImmediate(() => callback(err, res))
-
-    multihashing.digest(msg, HASH_ALGORITHM, (err, digest) => {
-      if (err) { return done(err) }
-      try {
-        sig = secp256k1.signatureImport(sig)
-        const valid = secp256k1.verify(digest, sig, key)
-        return done(null, valid)
-      } catch (err) { done(err) }
+  async function hashAndVerify (key, sig, msg) {
+    const digest = await new Promise((resolve, reject) => {
+      multihashing.digest(msg, HASH_ALGORITHM, (err, digest) => {
+        if (err) return reject(err)
+        resolve(digest)
+      })
     })
+    sig = secp256k1.signatureImport(sig)
+    return secp256k1.verify(digest, sig, key)
   }
 
   function compressPublicKey (key) {
@@ -76,14 +67,14 @@ module.exports = (randomBytes) => {
   }
 
   return {
-    generateKey: generateKey,
-    privateKeyLength: privateKeyLength,
-    hashAndSign: hashAndSign,
-    hashAndVerify: hashAndVerify,
-    compressPublicKey: compressPublicKey,
-    decompressPublicKey: decompressPublicKey,
-    validatePrivateKey: validatePrivateKey,
-    validatePublicKey: validatePublicKey,
-    computePublicKey: computePublicKey
+    generateKey,
+    privateKeyLength,
+    hashAndSign,
+    hashAndVerify,
+    compressPublicKey,
+    decompressPublicKey,
+    validatePrivateKey,
+    validatePublicKey,
+    computePublicKey
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,8 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       this._key = key
     }
 
-    verify (data, sig, callback) {
-      ensure(callback)
-      crypto.hashAndVerify(this._key, sig, data, callback)
+    async verify (data, sig) {
+      return crypto.hashAndVerify(this._key, sig, data)
     }
 
     marshal () {
@@ -31,9 +30,13 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       return this.bytes.equals(key.bytes)
     }
 
-    hash (callback) {
-      ensure(callback)
-      multihashing(this.bytes, 'sha2-256', callback)
+    async hash () {
+      return new Promise((resolve, reject) => {
+        multihashing(this.bytes, 'sha2-256', (err, res) => {
+          if (err) return reject(err)
+          resolve(res)
+        })
+      })
     }
   }
 
@@ -45,9 +48,8 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       crypto.validatePublicKey(this._publicKey)
     }
 
-    sign (message, callback) {
-      ensure(callback)
-      crypto.hashAndSign(this._key, message, callback)
+    async sign (message) {
+      return crypto.hashAndSign(this._key, message)
     }
 
     get public () {
@@ -69,43 +71,27 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
       return this.bytes.equals(key.bytes)
     }
 
-    hash (callback) {
-      ensure(callback)
-      multihashing(this.bytes, 'sha2-256', callback)
+    async hash () {
+      return new Promise((resolve, reject) => {
+        multihashing(this.bytes, 'sha2-256', (err, res) => {
+          if (err) return reject(err)
+          resolve(res)
+        })
+      })
     }
   }
 
-  function unmarshalSecp256k1PrivateKey (bytes, callback) {
-    callback(null, new Secp256k1PrivateKey(bytes), null)
+  async function unmarshalSecp256k1PrivateKey (bytes) {
+    return new Secp256k1PrivateKey(bytes)
   }
 
   function unmarshalSecp256k1PublicKey (bytes) {
     return new Secp256k1PublicKey(bytes)
   }
 
-  function generateKeyPair (_bits, callback) {
-    if (callback === undefined && typeof _bits === 'function') {
-      callback = _bits
-    }
-
-    ensure(callback)
-
-    crypto.generateKey((err, privateKeyBytes) => {
-      if (err) { return callback(err) }
-
-      let privkey
-      try {
-        privkey = new Secp256k1PrivateKey(privateKeyBytes)
-      } catch (err) { return callback(err) }
-
-      callback(null, privkey)
-    })
-  }
-
-  function ensure (callback) {
-    if (typeof callback !== 'function') {
-      throw new Error('callback is required')
-    }
+  async function generateKeyPair () {
+    const privateKeyBytes = await crypto.generateKey()
+    return new Secp256k1PrivateKey(privateKeyBytes)
   }
 
   return {

--- a/test/secp256k1.spec.js
+++ b/test/secp256k1.spec.js
@@ -6,8 +6,6 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const Buffer = require('safe-buffer').Buffer
-
 const libp2pCrypto = require('libp2p-crypto')
 const keysPBM = libp2pCrypto.keys.keysPBM
 const randomBytes = libp2pCrypto.randomBytes
@@ -17,72 +15,46 @@ describe('secp256k1 keys', () => {
   let key
   const secp256k1 = require('../src')(keysPBM, randomBytes)
 
-  before((done) => {
-    secp256k1.generateKeyPair((err, _key) => {
-      expect(err).to.not.exist()
-      key = _key
-      done()
-    })
+  before(async () => {
+    key = await secp256k1.generateKeyPair()
   })
 
-  it('generates a valid key', (done) => {
+  it('generates a valid key', async () => {
     expect(key).to.be.an.instanceof(secp256k1.Secp256k1PrivateKey)
     expect(key.public).to.be.an.instanceof(secp256k1.Secp256k1PublicKey)
 
-    key.hash((err, digest) => {
-      expect(err).to.not.exist()
-      expect(digest).to.have.length(34)
+    const digest = await key.hash()
+    expect(digest).to.have.length(34)
 
-      key.public.hash((err, digest) => {
-        expect(err).to.not.exist()
-        expect(digest).to.have.length(34)
-        done()
-      })
-    })
+    const publicDigest = await key.public.hash()
+    expect(publicDigest).to.have.length(34)
   })
 
-  it('optionally accepts a `bits` argument when generating a key', (done) => {
-    secp256k1.generateKeyPair(256, (err, _key) => {
-      expect(err).to.not.exist()
-      expect(_key).to.be.an.instanceof(secp256k1.Secp256k1PrivateKey)
-      done()
-    })
+  it('optionally accepts a `bits` argument when generating a key', async () => {
+    const _key = await secp256k1.generateKeyPair(256)
+    expect(_key).to.be.an.instanceof(secp256k1.Secp256k1PrivateKey)
   })
 
-  it('requires a callback to generate a key', () => {
-    expect(() => secp256k1.generateKeyPair()).to.throw()
-  })
-
-  it('signs', (done) => {
+  it('signs', async () => {
     const text = randomBytes(512)
-
-    key.sign(text, (err, sig) => {
-      expect(err).to.not.exist()
-
-      key.public.verify(text, sig, (err, res) => {
-        expect(err).to.not.exist()
-        expect(res).to.equal(true)
-        done()
-      })
-    })
+    const sig = await key.sign(text)
+    const res = await key.public.verify(text, sig)
+    expect(res).to.equal(true)
   })
 
-  it('encoding', (done) => {
+  it('encoding', async () => {
     const keyMarshal = key.marshal()
-    secp256k1.unmarshalSecp256k1PrivateKey(keyMarshal, (err, key2) => {
-      expect(err).to.not.exist()
-      const keyMarshal2 = key2.marshal()
+    const key2 = await secp256k1.unmarshalSecp256k1PrivateKey(keyMarshal)
+    const keyMarshal2 = key2.marshal()
 
-      expect(keyMarshal).to.eql(keyMarshal2)
+    expect(keyMarshal).to.eql(keyMarshal2)
 
-      const pk = key.public
-      const pkMarshal = pk.marshal()
-      const pk2 = secp256k1.unmarshalSecp256k1PublicKey(pkMarshal)
-      const pkMarshal2 = pk2.marshal()
+    const pk = key.public
+    const pkMarshal = pk.marshal()
+    const pk2 = secp256k1.unmarshalSecp256k1PublicKey(pkMarshal)
+    const pkMarshal2 = pk2.marshal()
 
-      expect(pkMarshal).to.eql(pkMarshal2)
-      done()
-    })
+    expect(pkMarshal).to.eql(pkMarshal2)
   })
 
   describe('key equals', () => {
@@ -92,43 +64,27 @@ describe('secp256k1 keys', () => {
       expect(key.public.equals(key.public)).to.eql(true)
     })
 
-    it('not equals other key', (done) => {
-      secp256k1.generateKeyPair(256, (err, key2) => {
-        expect(err).to.not.exist()
-
-        expect(key.equals(key2)).to.eql(false)
-        expect(key2.equals(key)).to.eql(false)
-        expect(key.public.equals(key2.public)).to.eql(false)
-        expect(key2.public.equals(key.public)).to.eql(false)
-        done()
-      })
+    it('not equals other key', async () => {
+      const key2 = await secp256k1.generateKeyPair(256)
+      expect(key.equals(key2)).to.eql(false)
+      expect(key2.equals(key)).to.eql(false)
+      expect(key.public.equals(key2.public)).to.eql(false)
+      expect(key2.public.equals(key.public)).to.eql(false)
     })
   })
 
-  it('sign and verify', (done) => {
+  it('sign and verify', async () => {
     const data = Buffer.from('hello world')
-    key.sign(data, (err, sig) => {
-      expect(err).to.not.exist()
-
-      key.public.verify(data, sig, (err, valid) => {
-        expect(err).to.not.exist()
-        expect(valid).to.eql(true)
-        done()
-      })
-    })
+    const sig = await key.sign(data)
+    const valid = await key.public.verify(data, sig)
+    expect(valid).to.eql(true)
   })
 
-  it('fails to verify for different data', (done) => {
+  it('fails to verify for different data', async () => {
     const data = Buffer.from('hello world')
-    key.sign(data, (err, sig) => {
-      expect(err).to.not.exist()
-
-      key.public.verify(Buffer.from('hello'), sig, (err, valid) => {
-        expect(err).to.not.exist()
-        expect(valid).to.eql(false)
-        done()
-      })
-    })
+    const sig = await key.sign(data)
+    const valid = await key.public.verify(Buffer.from('hello'), sig)
+    expect(valid).to.eql(false)
   })
 })
 
@@ -136,25 +92,23 @@ describe('key generation error', () => {
   let generateKey
   let secp256k1
 
-  before((done) => {
+  before(() => {
     generateKey = crypto.generateKey
-    crypto.generateKey = (callback) => callback(new Error('Error generating key'))
+    crypto.generateKey = async () => { throw new Error('Error generating key') }
     secp256k1 = require('../src')(keysPBM, randomBytes, crypto)
-
-    done()
   })
 
-  after((done) => {
+  after(() => {
     crypto.generateKey = generateKey
-    done()
   })
 
-  it('returns an error if key generation fails', (done) => {
-    secp256k1.generateKeyPair((err, key) => {
-      expect(err).to.exist()
-      expect(key).to.not.exist()
-      done()
-    })
+  it('returns an error if key generation fails', async () => {
+    try {
+      await secp256k1.generateKeyPair()
+    } catch (err) {
+      return expect(err.message).to.equal('Error generating key')
+    }
+    throw new Error('Expected error to be thrown')
   })
 })
 
@@ -162,25 +116,23 @@ describe('handles generation of invalid key', () => {
   let generateKey
   let secp256k1
 
-  before((done) => {
+  before(() => {
     generateKey = crypto.generateKey
-    crypto.generateKey = (callback) => { callback(null, Buffer.from('not a real key')) }
+    crypto.generateKey = async () => Buffer.from('not a real key')
     secp256k1 = require('../src')(keysPBM, randomBytes, crypto)
-
-    done()
   })
 
-  after((done) => {
+  after(() => {
     crypto.generateKey = generateKey
-    done()
   })
 
-  it('returns an error if key generator returns an invalid key', (done) => {
-    secp256k1.generateKeyPair((err, key) => {
-      expect(err).to.exist()
-      expect(key).to.not.exist()
-      done()
-    })
+  it('returns an error if key generator returns an invalid key', async () => {
+    try {
+      await secp256k1.generateKeyPair()
+    } catch (err) {
+      return expect(err.message).to.equal('Invalid private key')
+    }
+    throw new Error('Expected error to be thrown')
   })
 })
 
@@ -188,101 +140,90 @@ describe('crypto functions', () => {
   let privKey
   let pubKey
 
-  before((done) => {
-    crypto.generateKey((err, _key) => {
-      expect(err).to.not.exist()
-      privKey = _key
-      pubKey = crypto.computePublicKey(privKey)
-      done()
-    })
+  before(async () => {
+    privKey = await crypto.generateKey()
+    pubKey = crypto.computePublicKey(privKey)
   })
 
-  it('generates valid keys', (done) => {
+  it('generates valid keys', () => {
     expect(() => {
       crypto.validatePrivateKey(privKey)
       crypto.validatePublicKey(pubKey)
     }).to.not.throw()
-    done()
   })
 
-  it('does not validate an invalid key', (done) => {
+  it('does not validate an invalid key', () => {
     expect(() => crypto.validatePublicKey(Buffer.from('42'))).to.throw()
     expect(() => crypto.validatePrivateKey(Buffer.from('42'))).to.throw()
-    done()
   })
 
-  it('validates a correct signature', (done) => {
-    crypto.hashAndSign(privKey, Buffer.from('hello'), (err, sig) => {
-      expect(err).to.not.exist()
-      crypto.hashAndVerify(pubKey, sig, Buffer.from('hello'), (err, valid) => {
-        expect(err).to.not.exist()
-        expect(valid).to.equal(true)
-        done()
-      })
-    })
+  it('validates a correct signature', async () => {
+    const sig = await crypto.hashAndSign(privKey, Buffer.from('hello'))
+    const valid = await crypto.hashAndVerify(pubKey, sig, Buffer.from('hello'))
+    expect(valid).to.equal(true)
   })
 
-  it('errors if given a null buffer to sign', (done) => {
-    crypto.hashAndSign(privKey, null, (err, sig) => {
-      expect(err).to.exist()
-      expect(sig).to.not.exist()
-      done()
-    })
+  it('errors if given a null buffer to sign', async () => {
+    try {
+      await crypto.hashAndSign(privKey, null)
+    } catch (err) {
+      return // expected
+    }
+    throw new Error('Expected error to be thrown')
   })
 
-  it('errors when signing with an invalid key', (done) => {
-    crypto.hashAndSign(Buffer.from('42'), Buffer.from('Hello'), (err, sig) => {
-      expect(err).to.exist()
-      expect(sig).to.not.exist()
-      done()
-    })
+  it('errors when signing with an invalid key', async () => {
+    try {
+      await crypto.hashAndSign(Buffer.from('42'), Buffer.from('Hello'))
+    } catch (err) {
+      return expect(err.message).to.equal('private key length is invalid')
+    }
+    throw new Error('Expected error to be thrown')
   })
 
-  it('errors if given a null buffer to validate', (done) => {
-    crypto.hashAndSign(privKey, Buffer.from('hello'), (err, sig) => {
-      expect(err).to.not.exist()
+  it('errors if given a null buffer to validate', async () => {
+    const sig = await crypto.hashAndSign(privKey, Buffer.from('hello'))
 
-      crypto.hashAndVerify(privKey, sig, null, (err, valid) => {
-        expect(err).to.exist()
-        expect(valid).to.not.exist()
-        done()
-      })
-    })
+    try {
+      await crypto.hashAndVerify(privKey, sig, null)
+    } catch (err) {
+      return // expected
+    }
+    throw new Error('Expected error to be thrown')
   })
 
-  it('errors when validating a message with an invalid signature', (done) => {
-    crypto.hashAndVerify(pubKey, Buffer.from('invalid-sig'), Buffer.from('hello'), (err, valid) => {
-      expect(err).to.exist()
-      expect(valid).to.not.exist()
-      done()
-    })
+  it('errors when validating a message with an invalid signature', async () => {
+    try {
+      await crypto.hashAndVerify(pubKey, Buffer.from('invalid-sig'), Buffer.from('hello'))
+    } catch (err) {
+      return expect(err.message).to.equal('couldn\'t parse DER signature')
+    }
+    throw new Error('Expected error to be thrown')
   })
 
-  it('errors when signing with an invalid key', (done) => {
-    crypto.hashAndSign(Buffer.from('42'), Buffer.from('Hello'), (err, sig) => {
-      expect(err).to.exist()
-      expect(sig).to.not.exist()
-      done()
-    })
+  it('errors when signing with an invalid key', async () => {
+    try {
+      await crypto.hashAndSign(Buffer.from('42'), Buffer.from('Hello'))
+    } catch (err) {
+      return expect(err.message).to.equal('private key length is invalid')
+    }
+    throw new Error('Expected error to be thrown')
   })
 
-  it('throws when compressing an invalid public key', (done) => {
+  it('throws when compressing an invalid public key', () => {
     expect(() => crypto.compressPublicKey(Buffer.from('42'))).to.throw()
-    done()
   })
 
-  it('throws when decompressing an invalid public key', (done) => {
+  it('throws when decompressing an invalid public key', () => {
     expect(() => crypto.decompressPublicKey(Buffer.from('42'))).to.throw()
-    done()
   })
 
-  it('compresses/decompresses a valid public key', (done) => {
+  it('compresses/decompresses a valid public key', () => {
     const decompressed = crypto.decompressPublicKey(pubKey)
     expect(decompressed).to.exist()
     expect(decompressed.length).to.be.eql(65)
     const recompressed = crypto.compressPublicKey(decompressed)
     expect(recompressed).to.eql(pubKey)
-    done()
   })
 })
 
@@ -290,43 +231,32 @@ describe('go interop', () => {
   const secp256k1 = require('../src')(keysPBM, randomBytes)
   const fixtures = require('./fixtures/go-interop')
 
-  it('loads a private key marshaled by go-libp2p-crypto', (done) => {
+  it('loads a private key marshaled by go-libp2p-crypto', async () => {
     // we need to first extract the key data from the protobuf, which is
     // normally handled by js-libp2p-crypto
     const decoded = keysPBM.PrivateKey.decode(fixtures.privateKey)
     expect(decoded.Type).to.eql(keysPBM.KeyType.Secp256k1)
 
-    secp256k1.unmarshalSecp256k1PrivateKey(decoded.Data, (err, key) => {
-      expect(err).to.not.exist()
-
-      expect(key).to.be.an.instanceof(secp256k1.Secp256k1PrivateKey)
-      expect(key.bytes).to.eql(fixtures.privateKey)
-      done()
-    })
+    const key = await secp256k1.unmarshalSecp256k1PrivateKey(decoded.Data)
+    expect(key).to.be.an.instanceof(secp256k1.Secp256k1PrivateKey)
+    expect(key.bytes).to.eql(fixtures.privateKey)
   })
 
-  it('loads a public key marshaled by go-libp2p-crypto', (done) => {
+  it('loads a public key marshaled by go-libp2p-crypto', () => {
     const decoded = keysPBM.PublicKey.decode(fixtures.publicKey)
     expect(decoded.Type).to.be.eql(keysPBM.KeyType.Secp256k1)
 
     const key = secp256k1.unmarshalSecp256k1PublicKey(decoded.Data)
     expect(key).to.be.an.instanceof(secp256k1.Secp256k1PublicKey)
     expect(key.bytes).to.eql(fixtures.publicKey)
-    done()
   })
 
-  it('generates the same signature as go-libp2p-crypto', (done) => {
+  it('generates the same signature as go-libp2p-crypto', async () => {
     const decoded = keysPBM.PrivateKey.decode(fixtures.privateKey)
     expect(decoded.Type).to.eql(keysPBM.KeyType.Secp256k1)
 
-    secp256k1.unmarshalSecp256k1PrivateKey(decoded.Data, (err, key) => {
-      expect(err).to.not.exist()
-
-      key.sign(fixtures.message, (err, sig) => {
-        expect(err).to.not.exist()
-        expect(sig).to.eql(fixtures.signature)
-        done()
-      })
-    })
+    const key = await secp256k1.unmarshalSecp256k1PrivateKey(decoded.Data)
+    const sig = await key.sign(fixtures.message)
+    expect(sig).to.eql(fixtures.signature)
   })
 })


### PR DESCRIPTION
This PR changes this module to remove callbacks and use async/await. The API is unchanged aside from the obvious removal of the `callback` parameter.

depends on

* [x] https://github.com/multiformats/js-multihashing-async/pull/37

refs https://github.com/ipfs/js-ipfs/issues/1670