### PR TITLE
Update badges for consistency across libp2p repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 # js-libp2p-crypto-secp256k1
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
+[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
 ![](https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square)
 ![](https://img.shields.io/badge/Node.js-%3E%3D4.0.0-orange.svg?style=flat-square)
 
 > Support for secp256k1 keys in js-libp2p-crypto
 
-This repo contains a [js-libp2p-crypto](https://github.com/libp2p/js-libp2p-crypto)-compatible 
-implementation of cryptographic signature generation and verification using the 
-[secp256k1 elliptic curve](https://en.bitcoin.it/wiki/Secp256k1) popularized by Bitcoin and other 
+This repo contains a [js-libp2p-crypto](https://github.com/libp2p/js-libp2p-crypto)-compatible
+implementation of cryptographic signature generation and verification using the
+[secp256k1 elliptic curve](https://en.bitcoin.it/wiki/Secp256k1) popularized by Bitcoin and other
 crypto currencies.  
 
 ## Lead Captain


### PR DESCRIPTION
This is one of many PRs to get our README badges all consistently
referring to libp2p in places where they currently refer to IPFS.

The changes are:

- any existing "Made by Protocol Labs" badges that link to `ipn.io` have been
changed to link to `protocol.ai`
- the project badge has been changed to libp2p, with the yellow color
- the IRC badge links to the `#libp2p` channel
- the "Made by PL", project, and IRC badges appear in that order
- the Standard Readme badge has been removed, if present
- badges for Travis CI have been removed if the current state is "unknown" and
this repo lacks a `.travis.yml` file
- badges for Coveralls have been removed if the state is "unknown"


Since this is a cookie-cutter message shared by many PRs to various repos,
some of the changes above may not apply to this specific PR.