### PR TITLE
Provide only one arg to callback from unmarshalSecp256k1PrivateKey

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ module.exports = (keysProtobuf, randomBytes, crypto) => {
   }
 
   function unmarshalSecp256k1PrivateKey (bytes, callback) {
-    callback(null, new Secp256k1PrivateKey(bytes), null)
+    callback(null, new Secp256k1PrivateKey(bytes))
   }
 
   function unmarshalSecp256k1PublicKey (bytes) {


### PR DESCRIPTION
In `unmarshalSecp256k1PrivateKey`, supply only the private key to the callback, as the API stipulates.

Fixes #7.